### PR TITLE
fix some issue.

### DIFF
--- a/libhinawa.spec
+++ b/libhinawa.spec
@@ -1,0 +1,65 @@
+Name:			libhinawa
+Version:		0.5.0
+Release:		1%{?dist}
+Summary:		Hinawa is an gobject introspection library for devices connected to IEEE 1394 bus.
+
+License:		LGPLv2
+URL:			https://github.com/takaswie/libhinawa
+Source:			%{name}-%{version}.tar.gz
+
+BuildRequires:  automake >= 1.10
+BuildRequires:  autoconf >= 2.62
+BuildRequires:  libtool >= 2.2.6
+BuildRequires:  glib2 >= 2.32
+BuildRequires:  gtk-doc >= 1.18-2
+BuildRequires:  gobject-introspection >= 1.32.1
+
+
+%description
+Hinawa is an gobject introspection library for devices connected to
+IEEE 1394 bus. This library supports any types of transactions over
+IEEE 1394 bus.  This library also supports some functionality which
+ALSA firewire stack produces.
+
+%package		devel
+Summary:		Development files for %{name}
+Requires:		%{name}%{?_isa} = %{version}-%{release}
+
+%description	devel
+The %{name}-devel package contains libraries and header files for
+developing applications that use %{name}.
+
+
+%prep
+%setup -q
+
+
+%build
+./autogen.sh
+%configure --enable-gtk-doc --prefix=$RPM_BUILD_ROOT --docdir=/usr/share/doc/hinawa/
+#make %{?_smp_mflags}
+make
+
+
+%install
+rm -rf $RPM_BUILD_ROOT
+%make_install
+find $RPM_BUILD_ROOT -name '*.la' -exec rm -f {} ';'
+
+
+%post -p /sbin/ldconfig
+
+%postun -p /sbin/ldconfig
+
+
+%files
+%{_libdir}/libhinawa.*
+%{_libdir}/girepository-1.0/*
+/usr/include/hinawa/*
+/usr/share/gir-1.0/*
+/usr/share/gtk-doc/html/hinawa/*
+%{_docdir}/hinawa/*
+
+%changelog
+* Tue Mar  3 2015 Yoshihiro Okada
+- 

--- a/libhinawa.spec
+++ b/libhinawa.spec
@@ -10,9 +10,9 @@ Source:			%{name}-%{version}.tar.gz
 BuildRequires:  automake >= 1.10
 BuildRequires:  autoconf >= 2.62
 BuildRequires:  libtool >= 2.2.6
-BuildRequires:  glib2 >= 2.32
+BuildRequires:  glib2 >= 2.32, glib2-devel >= 2.32
 BuildRequires:  gtk-doc >= 1.18-2
-BuildRequires:  gobject-introspection >= 1.32.1
+BuildRequires:  gobject-introspection >= 1.32.1, gobject-introspection-devel >= 1.32.1
 
 
 %description
@@ -55,10 +55,13 @@ find $RPM_BUILD_ROOT -name '*.la' -exec rm -f {} ';'
 %files
 %{_libdir}/libhinawa.*
 %{_libdir}/girepository-1.0/*
+
+%files devel
 /usr/include/hinawa/*
 /usr/share/gir-1.0/*
 /usr/share/gtk-doc/html/hinawa/*
 %{_docdir}/hinawa/*
+
 
 %changelog
 * Tue Mar  3 2015 Yoshihiro Okada


### PR DESCRIPTION
buildrequireの不足分の追加。
通常パッケージとdevelopmentパッケージの分離。

Notice:
rpmbuildを実行するには、事前にlibhinawa-0.5.0.tar.gzをローカルに準備する必要がある。
