### PR TITLE
snd_unit: fix warning about strict aliasing rules

### DIFF
--- a/src/backport.h
+++ b/src/backport.h
@@ -3,6 +3,7 @@
 
 #include <linux/ioctl.h>
 #include <linux/types.h>
+#include <glib.h>
 
 /* events can be read() from the hwdep device */
 
@@ -67,10 +68,15 @@ union snd_firewire_event {
 #define SNDRV_FIREWIRE_TYPE_TASCAM	6
 /* RME, MOTU, ... */
 
+typedef union {
+	unsigned char guid[8];
+	guint64 guid64;
+} snd_firewire_guid_info;
+
 struct snd_firewire_get_info {
 	unsigned int type; /* SNDRV_FIREWIRE_TYPE_xxx */
 	unsigned int card; /* same as fw_cdev_get_info.card */
-	unsigned char guid[8];
+	snd_firewire_guid_info guid_info;
 	char device_name[16]; /* device node in /dev */
 };
 

--- a/src/snd_unit.c
+++ b/src/snd_unit.c
@@ -83,7 +83,7 @@ static void snd_unit_get_property(GObject *obj, guint id,
 		break;
 	case SND_UNIT_PROP_TYPE_GUID:
 		g_value_set_uint64(val,
-				GUINT64_FROM_BE(*((guint64 *)priv->info.guid)));
+				GUINT64_FROM_BE(priv->info.guid_info.guid64));
 		break;
 	case SND_UNIT_PROP_TYPE_STREAMING:
 		g_value_set_boolean(val, priv->streaming);


### PR DESCRIPTION
  snd_unit.c: In function 'snd_unit_get_property':
  snd_unit.c:86:5: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
       GUINT64_FROM_BE(*((guint64 *)priv->info.guid)));
       ^