### PR TITLE
debian: follow the declared debian compatibility in debian/compat

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: libhinawa
 Section: libs
 Priority: optional
 Maintainer: Takashi Sakamoto <o-takashi@sakamocchi.jp>
-Build-Depends: debhelper (>= 8.0.0), autotools-dev,
+Build-Depends: debhelper (>= 9), autotools-dev,
     automake (>= 1.10), autoconf (>= 2.62), libtool (>= 2.2.6),
     libglib2.0-dev (>= 2.32.0),
     gtk-doc-tools (>= 1.18-2),


### PR DESCRIPTION
At least, Ubuntu precise or later, Debian GNU/Linux wheezy or later
are supported even though debhelper 9 is required.