### PR TITLE
debian: add missing license description

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -5,3 +5,7 @@ Source: https://github.com/takaswie/libhinawa
 Files: *
 Copyright: 2015 Takashi Sakamoto <o-takashi@sakamocchi.jp>
 License: LGPLv2
+
+License: LGPL-2.1
+ On Debian GNU/Linux systems, the complete text of the LGPL 2.1
+ license can be found in `/usr/share/common-licenses/LGPL-2.1'.


### PR DESCRIPTION
This commit fixes following the warning:

  W: libhinawa source: missing-license-paragraph-in-dep5-copyright lgplv2 (paragraph at line 5)

License: field should be fixed too. (another PR)