### PR TITLE
debian: add missing debian revision

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-libhinawa (0.6.0) unstable; urgency=medium
+libhinawa (0.6.0-1) unstable; urgency=medium
 
   * New upstream release 0.6.0
    * Use blocking I/O to save CPU usage


### PR DESCRIPTION
Without this change, dpkg-source claims an error.

  dpkg-source: error: can't build with source format '3.0 (quilt)': non-native package version does not contain a revision