### PR TITLE
Add missing internal.h

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -32,6 +32,7 @@ libhinawa_la_SOURCES =				\
 	fw_req.c				\
 	fw_fcp.h				\
 	fw_fcp.c				\
+	internal.h				\
 	snd_unit.h				\
 	snd_unit.c
 


### PR DESCRIPTION
This commit fixes following the error:

  fw_unit.c:9:22: fatal error: internal.h: No such file or directory
  compilation terminated.