### PR TITLE
debian: use simple rules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -4,60 +4,8 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
-clean:
-	dh_prep
-	dh_clean
-	rm -f build
-	-$(MAKE) -i distclean
-	rm -f config.h config.log config.status config.sub
-	rm -f aclocal.m4
-	rm -fR m4
-	rm -f configure-stamp build-stamp
+%:
+	dh $@ --with autotools-dev --with gir
 
-configure: configure-stamp
-configure-stamp:
-	# Add here commands to configure the package.
-	./autogen.sh
+override_dh_auto_configure:
 	dh_auto_configure -- --prefix=/usr --enable-gtk-doc --enable-static=no
-
-	touch configure-stamp
-
-build: build-stamp
-build-stamp: configure-stamp
-	dh_testdir
-	# Add here commands to compile the package.
-	$(MAKE)
-
-	touch $@
-
-install: build
-	dh_testdir
-	dh_prep
-	dh_clean
-	dh_installdirs
-	# Add here commands to install the package into debian/tmp
-	$(MAKE) DESTDIR=$(CURDIR)/debian/tmp install
-
-binary: binary-indep binary-arch
-
-binary-arch: build install
-	dh_testdir
-	dh_install
-	dh_installdocs
-	dh_installchangelogs -a ChangeLog
-	dh_installman
-	dh_link
-	dh_compress
-	dh_fixperms
-	dh_strip --dbg-package=libhinawa-dbg
-	dh_makeshlibs
-	dh_shlibdeps -- --ignore-missing-info
-	dh_girepository -l src:debian/libhinawa-dev/usr/share/gir-1.0
-	dh_installdeb
-	dh_gencontrol
-	dh_md5sums
-	dh_builddeb
-
-binary-indep: build install
-
-.PHONY: clean configure build install binary binary-arch binary-indep


### PR DESCRIPTION
This PR make debian/rules simple.

* Remove redundant override rules
* Do not generate -dbg package by hand
