### PR TITLE
debian: remote redundant --prefix option

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -8,4 +8,4 @@
 	dh $@ --with autotools-dev --with gir
 
 override_dh_auto_configure:
-	dh_auto_configure -- --prefix=/usr --enable-gtk-doc --enable-static=no
+	dh_auto_configure -- --enable-gtk-doc --enable-static=no


### PR DESCRIPTION
dh_auto_configure works well without it.

  dh_auto_configure -- --enable-gtk-doc --enable-static=no
        ./configure --build=x86_64-linux-gnu --prefix=/usr --includedir=\${prefix}/include --mandir=\${prefix}/share/man --infodir=\${prefix}/share/info --sysconfdir=/etc --localstatedir=/var --disable-silent-rules --libdir=\${prefix}/lib/x86_64-linux-gnu --libexecdir=\${prefix}/lib/x86_64-linux-gnu --disable-maintainer-mode --disable-dependency-tracking --enable-gtk-doc --enable-static=no