### PR TITLE
debian: drop -dbg package with -dbgsym package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -43,20 +43,3 @@ Depends: ${misc:Depends},
 Description: libhinawa development package
  This package contains libraries and header files for
  developing applications that use libhinawa.
-
-Package: libhinawa-dbg
-Section: debug
-Priority: extra
-Architecture: any
-Depends: ${misc:Depends},
-    libhinawa0 (= ${binary:Version})
-Description: libhinawa debugging symbols
- This package contains libhinawa debugging symbols.
- .
- Usually, there is no need to generate -dbg by manually because -dbgsym
- package is generated automatically on Debian and as a result it becomes to
- empty package.
- .
- This -dbg package is kept for Debian derivative distribution such as Ubuntu.
- (In contrast to Debian, it is required to install Ubuntu specific package -
- pkg-create-dbgsym explicitly)


### PR DESCRIPTION
I decide to follow recent fashion about packages for debugging symbols.
This commit cancels to generate -dbg package by myself. Packages for
this purpose are generated according to build environment.