### PR TITLE
Update libhinawa.spec

### DIFF
--- a/libhinawa.spec
+++ b/libhinawa.spec
@@ -35,7 +35,7 @@ developing applications that use %{name}.
 
 
 %build
-%configure --enable-gtk-doc --prefix=$RPM_BUILD_ROOT
+%configure --enable-gtk-doc
 #make %{?_smp_mflags}
 make
 

--- a/libhinawa.spec
+++ b/libhinawa.spec
@@ -1,7 +1,7 @@
 Name:			libhinawa
 Version:		0.7.0
 Release:		1%{?dist}
-Summary:		Hinawa is an gobject introspection library for devices connected to IEEE 1394 bus.
+Summary:		Hinawa is an gobject introspection library for devices connected to IEEE 1394 bus
 
 License:		LGPLv2
 URL:			https://github.com/takaswie/libhinawa

--- a/libhinawa.spec
+++ b/libhinawa.spec
@@ -56,10 +56,10 @@ find $RPM_BUILD_ROOT -name '*.la' -exec rm -f {} ';'
 %{_libdir}/girepository-1.0/*
 
 %files devel
-/usr/include/libhinawa/*
-/usr/lib/*/pkgconfig/*
-/usr/share/gir-1.0/*
-/usr/share/gtk-doc/html/hinawa/*
+%{_includedir}/libhinawa/*
+%{_libdir}/pkgconfig/*
+%{_datadir}/gir-1.0/*
+%{_datadir}/gtk-doc/html/hinawa/*
 %{_docdir}/libhinawa/*
 
 

--- a/libhinawa.spec
+++ b/libhinawa.spec
@@ -35,7 +35,7 @@ developing applications that use %{name}.
 
 
 %build
-%configure --enable-gtk-doc
+%configure --enable-gtk-doc --disable-static
 #make %{?_smp_mflags}
 make
 
@@ -52,12 +52,13 @@ find $RPM_BUILD_ROOT -name '*.la' -exec rm -f {} ';'
 
 
 %files
-%{_libdir}/libhinawa.*
+%{_libdir}/libhinawa.so.*
 %{_libdir}/girepository-1.0/*
 
 %files devel
 %{_includedir}/libhinawa/*
 %{_libdir}/pkgconfig/*
+%{_libdir}/libhinawa.so
 %{_datadir}/gir-1.0/*
 %{_datadir}/gtk-doc/html/hinawa/*
 %{_docdir}/libhinawa/*

--- a/libhinawa.spec
+++ b/libhinawa.spec
@@ -64,5 +64,8 @@ find $RPM_BUILD_ROOT -name '*.la' -exec rm -f {} ';'
 
 
 %changelog
+* Fri Feb  5 2016 HAYASHI Kentaro <hayashi@clear-code.com> - 0.7.0-1
+- new upstream release.
+
 * Tue Mar  3 2015 Yoshihiro Okada - 0.5.0-1
 - new upstream release.

--- a/libhinawa.spec
+++ b/libhinawa.spec
@@ -1,7 +1,7 @@
 Name:			libhinawa
 Version:		0.7.0
 Release:		1%{?dist}
-Summary:		Hinawa is an gobject introspection library for devices connected to IEEE 1394 bus
+Summary:		GObject introspection library for devices connected to IEEE 1394 bus
 
 License:		LGPLv2
 URL:			https://github.com/takaswie/libhinawa

--- a/libhinawa.spec
+++ b/libhinawa.spec
@@ -64,5 +64,5 @@ find $RPM_BUILD_ROOT -name '*.la' -exec rm -f {} ';'
 
 
 %changelog
-* Tue Mar  3 2015 Yoshihiro Okada
--
+* Tue Mar  3 2015 Yoshihiro Okada - 0.5.0-1
+- new upstream release.

--- a/libhinawa.spec
+++ b/libhinawa.spec
@@ -35,7 +35,6 @@ developing applications that use %{name}.
 
 
 %build
-./autogen.sh
 %configure --enable-gtk-doc --prefix=$RPM_BUILD_ROOT
 #make %{?_smp_mflags}
 make


### PR DESCRIPTION
It follows Fedora packaging guideline. (checked by rpmlint -i on Fedora 23)