### PR TITLE
Autotools: stop to install needless a header file

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -41,7 +41,6 @@ libhinawa_la_SOURCES =				\
 	hinawa.symbols
 
 pkginclude_HEADERS =				\
-	hinawa_sigs_marshal.h			\
 	fw_unit.h				\
 	fw_resp.h				\
 	fw_req.h				\


### PR DESCRIPTION
Marshal functions aren't needed for users.