### PR TITLE
fw_req: use 'guint32 *' instead of 'GArray *'

### DIFF
--- a/src/fw_fcp.c
+++ b/src/fw_fcp.c
@@ -143,7 +143,9 @@ void hinawa_fw_fcp_transact(HinawaFwFcp *self,
 	g_mutex_init(&local_lock);
 
 	/* Send this request frame. */
-	hinawa_fw_req_write(req, priv->unit, FCP_REQUEST_ADDR, trans.req_frame,
+	hinawa_fw_req_write(req, priv->unit, FCP_REQUEST_ADDR,
+			    (guint32 *)trans.req_frame->data,
+			    trans.req_frame->len,
 			    exception);
 	if (*exception != NULL)
 		goto end;

--- a/src/fw_req.h
+++ b/src/fw_req.h
@@ -46,11 +46,12 @@ struct _HinawaFwReqClass {
 GType hinawa_fw_req_get_type(void) G_GNUC_CONST;
 
 void hinawa_fw_req_write(HinawaFwReq *self, HinawaFwUnit *unit, guint64 addr,
-			 GArray *frame, GError **exception);
+			 guint32 *frame, guint quads, GError **exception);
 
 void hinawa_fw_req_read(HinawaFwReq *self, HinawaFwUnit *unit, guint64 addr,
-			GArray *frame, guint quads, GError **exception);
+			guint quads, guint32 **frame, guint *read_quads,
+			GError **exception);
 
-void hinawa_fw_req_lock(HinawaFwReq *self, HinawaFwUnit *unit,
-			guint64 addr, GArray **frame, GError **exception);
+void hinawa_fw_req_lock(HinawaFwReq *self, HinawaFwUnit *unit, guint64 addr,
+			guint **frame, guint quads, GError **exception);
 #endif

--- a/src/snd_dice.c
+++ b/src/snd_dice.c
@@ -122,7 +122,8 @@ void hinawa_snd_dice_transact(HinawaSndDice *self, guint64 addr,
 	g_cond_init(&waiter.cond);
 
 	waiter.bit_flag = bit_flag;
-	hinawa_snd_unit_write_transact(&self->parent_instance, addr, frame,
+	hinawa_snd_unit_write_transact(&self->parent_instance, addr,
+				       (guint32 *)frame->data, frame->len,
 				       exception);
 	if (*exception != NULL)
 		goto end;

--- a/src/snd_unit.c
+++ b/src/snd_unit.c
@@ -270,36 +270,42 @@ void hinawa_snd_unit_unlock(HinawaSndUnit *self, GError **exception)
  * hinawa_snd_unit_read_transact:
  * @self: A #HinawaSndUnit
  * @addr: A destination address of target device
- * @frame: (element-type guint32) (array) (out caller-allocates): a 32bit array
  * @len: the bytes to read
+ * @frame: (array length=read_len) (out) (nullable): The read data
+ * @read_len: (optional): The read bytes
  * @exception: A #GError
  *
  * Execute read transaction to the given unit.
  */
 void hinawa_snd_unit_read_transact(HinawaSndUnit *self,
-				   guint64 addr, GArray *frame, guint len,
+				   guint64 addr, guint len,
+                                   guint32 **frame, guint *read_len,
 				   GError **exception)
 {
 	HinawaSndUnitPrivate *priv;
 
+	*frame = NULL;
+	if (read_len)
+		*read_len = 0;
 	g_return_if_fail(HINAWA_IS_SND_UNIT(self));
 	priv = hinawa_snd_unit_get_instance_private(self);
 
-	hinawa_fw_req_read(priv->req, &self->parent_instance, addr, frame, len,
-			   exception);
+	hinawa_fw_req_read(priv->req, &self->parent_instance, addr,
+			   len, frame, read_len, exception);
 }
 
 /**
  * hinawa_snd_unit_write_transact:
  * @self: A #HinawaSndUnit
  * @addr: A destination address of target device
- * @frame: (element-type guint32) (array) (in): a 32bit array
+ * @frame: (array length=len): a 32bit array
+ * @len: the bytes to write
  * @exception: A #GError
  *
  * Execute write transactions to the given unit.
  */
 void hinawa_snd_unit_write_transact(HinawaSndUnit *self,
-				    guint64 addr, GArray *frame,
+				    guint64 addr, guint32 *frame, guint len,
 				    GError **exception)
 {
 	HinawaSndUnitPrivate *priv;
@@ -307,7 +313,7 @@ void hinawa_snd_unit_write_transact(HinawaSndUnit *self,
 	g_return_if_fail(HINAWA_IS_SND_UNIT(self));
 	priv = hinawa_snd_unit_get_instance_private(self);
 
-	hinawa_fw_req_write(priv->req, &self->parent_instance, addr, frame,
+	hinawa_fw_req_write(priv->req, &self->parent_instance, addr, frame, len,
 			    exception);
 }
 
@@ -315,13 +321,14 @@ void hinawa_snd_unit_write_transact(HinawaSndUnit *self,
  * hinawa_snd_unit_lock_transact:
  * @self: A #HinawaSndUnit
  * @addr: A destination address of target device
- * @frame: (element-type guint32) (array) (inout): a 32bit array
+ * @frame: (array length=len) (inout): a 32bit array
+ * @len: (in): the bytes to lock
  * @exception: A #GError
  *
  * Execute lock transaction to the given unit.
  */
 void hinawa_snd_unit_lock_transact(HinawaSndUnit *self,
-				   guint64 addr, GArray **frame,
+				   guint64 addr, guint32 **frame, guint len,
 				   GError **exception)
 {
 	HinawaSndUnitPrivate *priv;
@@ -329,7 +336,7 @@ void hinawa_snd_unit_lock_transact(HinawaSndUnit *self,
 	g_return_if_fail(HINAWA_IS_SND_UNIT(self));
 	priv = hinawa_snd_unit_get_instance_private(self);
 
-	hinawa_fw_req_lock(priv->req, &self->parent_instance, addr, frame,
+	hinawa_fw_req_lock(priv->req, &self->parent_instance, addr, frame, len,
 			   exception);
 }
 

--- a/src/snd_unit.h
+++ b/src/snd_unit.h
@@ -51,13 +51,14 @@ void hinawa_snd_unit_lock(HinawaSndUnit *self, GError **exception);
 void hinawa_snd_unit_unlock(HinawaSndUnit *self, GError **exception);
 
 void hinawa_snd_unit_read_transact(HinawaSndUnit *self,
-				   guint64 addr, GArray *frame, guint len,
+				   guint64 addr, guint len,
+				   guint32 **frame, guint *read_len,
 				   GError **exception);
 void hinawa_snd_unit_write_transact(HinawaSndUnit *self,
-				    guint64 addr, GArray *frame,
+				    guint64 addr, guint32 *frame, guint len,
 				    GError **exception);
 void hinawa_snd_unit_lock_transact(HinawaSndUnit *self,
-				   guint64 addr, GArray **frame,
+				   guint64 addr, guint32 **frame, guint len,
 				   GError **exception);
 
 void hinawa_snd_unit_listen(HinawaSndUnit *self, GError **exception);


### PR DESCRIPTION
GitHub: #14

GArray is convenience but we don't need it when we already have data and
data size.

Note that this change changes only fw_req. There are still GArray in
fw_resp.
