### PR TITLE
debian: bump standars-version to 3.9.8

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends: debhelper (>= 9), autotools-dev,
     gtk-doc-tools (>= 1.18-2),
     gobject-introspection (>= 1.32.1),
     libgirepository1.0-dev (>= 1.32.1)
-Standards-Version: 3.9.6
+Standards-Version: 3.9.8
 Homepage: https://github.com/takaswie/libhinawa
 Vcs-Browser: https://github.com/takaswie/libhinawa.git
 


### PR DESCRIPTION
debian policy is now revised to 3.9.8:
  ref. https://www.debian.org/doc/debian-policy/upgrading-checklist.html