### PR TITLE
debian: add Uploaders: field

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,5 @@
 libhinawa (0.7.0-2) unstable; urgency=medium
 
-  * Team upload.
   * debian/control
     - set Architecture: linux-any for all package to avoid build with non-linux
       arch (debian#823011).
@@ -10,7 +9,6 @@ libhinawa (0.7.0-2) unstable; urgency=medium
 
 libhinawa (0.7.0-1) unstable; urgency=medium
 
-  * Team upload.
   * New upstream release 0.7.0
   * debian/control
     - requires to debhelper 9 or later.

--- a/debian/control
+++ b/debian/control
@@ -2,6 +2,7 @@ Source: libhinawa
 Section: libs
 Priority: optional
 Maintainer: Takashi Sakamoto <o-takashi@sakamocchi.jp>
+Uploaders: HAYASHI Kentaro <hayashi@clear-code.com>
 Build-Depends: debhelper (>= 9), autotools-dev,
     automake (>= 1.10), autoconf (>= 2.62), libtool (>= 2.2.6),
     libglib2.0-dev (>= 2.32.0),


### PR DESCRIPTION
When Uploaders: field is specified, "* Team upload" entry is not needed
because it is used for the case who is not listed in Maintainer: nor
Uploaders: filed.