### PR TITLE
debian: add missing comment to fix pedantic notification

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ libhinawa (0.8.2-1) unstable; urgency=medium
 
   [ Takashi Sakamoto ]
   * New upstream release 0.8.2.
+  * Upload to unstable.
   * debian/compat
     - bump version to 10.
   * debian/control


### PR DESCRIPTION
P: experimental-to-unstable-without-comment